### PR TITLE
fix(rust-sdk): align tree-sitter core+grammars (ABI), surface set_language errors, add parse test

### DIFF
--- a/crates/hanzo-mcp-server/Cargo.toml
+++ b/crates/hanzo-mcp-server/Cargo.toml
@@ -47,15 +47,19 @@ rayon = "1.8"
 # Glob patterns
 glob = "0.3"
 
-# Search and AST
-tree-sitter = "0.20"
+# Search and AST.
+# Core + every grammar must stay on the same parser ABI (ABI 15 needs
+# core >= 0.23). Bumping a single grammar past the core's ABI makes
+# set_language fail at runtime — keep this whole set aligned to latest.
+tree-sitter = "0.26"
+tree-sitter-language = "0.1"  # canonical home of `LanguageFn` (grammars' LANGUAGE type)
 tree-sitter-rust = "0.24"
-tree-sitter-javascript = "0.20"
-tree-sitter-typescript = "0.20"
-tree-sitter-python = "0.20"
-tree-sitter-go = "0.20"
-tree-sitter-java = "0.20"
-tree-sitter-cpp = "0.20"
+tree-sitter-javascript = "0.25"
+tree-sitter-typescript = "0.23"
+tree-sitter-python = "0.25"
+tree-sitter-go = "0.25"
+tree-sitter-java = "0.23"
+tree-sitter-cpp = "0.23"
 tree-sitter-c = "0.24"
 
 # Vector store (optional)

--- a/crates/hanzo-mcp-server/src/lib.rs
+++ b/crates/hanzo-mcp-server/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod protocol;
+pub mod search;
 pub mod server;
 pub mod tools;
 

--- a/crates/hanzo-mcp-server/src/search/ast_search.rs
+++ b/crates/hanzo-mcp-server/src/search/ast_search.rs
@@ -1,56 +1,72 @@
-/// AST search using tree-sitter for semantic code understanding
+//! AST search using tree-sitter for semantic code understanding.
+//!
+//! Each grammar is loaded via its crate's `LANGUAGE` constant (a
+//! [`tree_sitter_language::LanguageFn`]). Core `tree-sitter` and every grammar must
+//! agree on the parser ABI — if a grammar is bumped past the core's supported
+//! ABI, [`Parser::set_language`] returns a [`LanguageError`] and we surface it
+//! loudly from [`AstSearcher::new`] rather than silently dropping it.
 
-use super::{SearchResult, MatchType};
-use std::path::{Path, PathBuf};
-use tree_sitter::{Language, Parser, Query, QueryCursor, Node};
-use walkdir::WalkDir;
+use super::{MatchType, SearchResult};
 use std::fs;
+use std::path::Path;
+use tree_sitter::{Language, Node, Parser, Query, QueryCursor, StreamingIterator};
+use tree_sitter_language::LanguageFn;
+use walkdir::WalkDir;
 
-/// TreeSitter language bindings
-extern "C" {
-    fn tree_sitter_rust() -> Language;
-    fn tree_sitter_javascript() -> Language;
-    fn tree_sitter_typescript() -> Language;
-    fn tree_sitter_python() -> Language;
-    fn tree_sitter_go() -> Language;
-    fn tree_sitter_java() -> Language;
-    fn tree_sitter_cpp() -> Language;
-    fn tree_sitter_c() -> Language;
-}
+/// Languages we can parse, paired with their tree-sitter grammar.
+const GRAMMARS: &[(&str, LanguageFn)] = &[
+    ("rust", tree_sitter_rust::LANGUAGE),
+    ("javascript", tree_sitter_javascript::LANGUAGE),
+    ("typescript", tree_sitter_typescript::LANGUAGE_TYPESCRIPT),
+    ("python", tree_sitter_python::LANGUAGE),
+    ("go", tree_sitter_go::LANGUAGE),
+    ("java", tree_sitter_java::LANGUAGE),
+    ("cpp", tree_sitter_cpp::LANGUAGE),
+    ("c", tree_sitter_c::LANGUAGE),
+];
 
-/// AST searcher using tree-sitter
+/// AST searcher using tree-sitter.
+///
+/// Holds one [`Language`] per supported language. Parsers are created
+/// on demand per parse so the searcher stays `&self`-shareable.
 pub struct AstSearcher {
-    parsers: std::collections::HashMap<String, Parser>,
+    languages: std::collections::HashMap<String, Language>,
 }
 
 impl AstSearcher {
-    /// Create new AST searcher
-    pub fn new() -> Self {
-        let mut searcher = Self {
-            parsers: std::collections::HashMap::new(),
-        };
-        
-        // Initialize parsers for different languages
-        searcher.init_parser("rust", unsafe { tree_sitter_rust() });
-        searcher.init_parser("javascript", unsafe { tree_sitter_javascript() });
-        searcher.init_parser("typescript", unsafe { tree_sitter_typescript() });
-        searcher.init_parser("python", unsafe { tree_sitter_python() });
-        searcher.init_parser("go", unsafe { tree_sitter_go() });
-        searcher.init_parser("java", unsafe { tree_sitter_java() });
-        searcher.init_parser("cpp", unsafe { tree_sitter_cpp() });
-        searcher.init_parser("c", unsafe { tree_sitter_c() });
-        
-        searcher
+    /// Create a new AST searcher, loading every supported grammar.
+    ///
+    /// Returns an error if any grammar's parser ABI is incompatible with the
+    /// linked `tree-sitter` core (the failure mode an ABI-mismatched grammar
+    /// bump produces). This makes such a mismatch impossible to ship silently.
+    pub fn new() -> Result<Self, tree_sitter::LanguageError> {
+        let mut languages = std::collections::HashMap::new();
+
+        for (name, language_fn) in GRAMMARS {
+            let language: Language = (*language_fn).into();
+            // Validate the ABI now, against a throwaway parser, so a mismatch
+            // is reported here instead of being swallowed at parse time.
+            let mut parser = Parser::new();
+            parser.set_language(&language)?;
+            languages.insert((*name).to_string(), language);
+        }
+
+        Ok(Self { languages })
     }
 
-    /// Initialize parser for a language
-    fn init_parser(&mut self, lang: &str, language: Language) {
+    /// Parse `source` for `lang`, returning the syntax tree and the language.
+    fn parse(&self, lang: &str, source: &str) -> Option<(tree_sitter::Tree, Language)> {
+        let language = self.languages.get(lang)?.clone();
         let mut parser = Parser::new();
-        parser.set_language(language).ok();
-        self.parsers.insert(lang.to_string(), parser);
+        // Safe to unwrap: every stored language was ABI-validated in `new`.
+        parser
+            .set_language(&language)
+            .expect("language ABI validated in AstSearcher::new");
+        let tree = parser.parse(source, None)?;
+        Some((tree, language))
     }
 
-    /// Search for AST patterns
+    /// Search for AST patterns.
     pub async fn search(
         &self,
         pattern: &str,
@@ -59,8 +75,7 @@ impl AstSearcher {
         max_results: usize,
     ) -> Result<Vec<SearchResult>, Box<dyn std::error::Error>> {
         let mut results = Vec::new();
-        
-        // Walk directory tree
+
         for entry in WalkDir::new(path)
             .follow_links(true)
             .into_iter()
@@ -68,98 +83,80 @@ impl AstSearcher {
             .filter(|e| e.file_type().is_file())
         {
             let file_path = entry.path();
-            
-            // Detect language from file extension
+
+            // Detect language from file extension unless one was forced.
             let lang = language.unwrap_or_else(|| detect_language(file_path));
-            
-            // Get parser for language
-            if let Some(parser) = self.parsers.get(lang) {
-                if let Ok(source) = fs::read_to_string(file_path) {
-                    // Parse the file
-                    if let Some(tree) = parser.clone().parse(&source, None) {
-                        // Search AST nodes
-                        let file_results = self.search_tree(
-                            &tree,
-                            &source,
-                            pattern,
-                            file_path,
-                            lang,
-                        );
-                        
-                        results.extend(file_results);
-                        
-                        if results.len() >= max_results {
-                            break;
-                        }
+
+            if !self.languages.contains_key(lang) {
+                continue;
+            }
+
+            if let Ok(source) = fs::read_to_string(file_path) {
+                if let Some((tree, grammar)) = self.parse(lang, &source) {
+                    let file_results =
+                        search_tree(&tree, &grammar, &source, pattern, file_path, lang);
+                    results.extend(file_results);
+
+                    if results.len() >= max_results {
+                        break;
                     }
                 }
             }
         }
-        
+
         results.truncate(max_results);
         Ok(results)
     }
+}
 
-    /// Search within a parsed tree
-    fn search_tree(
-        &self,
-        tree: &tree_sitter::Tree,
-        source: &str,
-        pattern: &str,
-        file_path: &Path,
-        language: &str,
-    ) -> Vec<SearchResult> {
-        let mut results = Vec::new();
-        let root_node = tree.root_node();
-        
-        // Build query based on pattern
-        let query_str = build_query_string(pattern, language);
-        
-        if let Ok(query) = Query::new(
-            self.parsers.get(language).unwrap().language().unwrap(),
-            &query_str,
-        ) {
-            let mut cursor = QueryCursor::new();
-            let matches = cursor.matches(&query, root_node, source.as_bytes());
-            
-            for match_ in matches {
-                for capture in match_.captures {
-                    let node = capture.node;
-                    let start = node.start_position();
-                    let end = node.end_position();
-                    
-                    // Extract match text
-                    let match_text = source[node.byte_range()].to_string();
-                    
-                    // Get context
-                    let (context_before, context_after) = get_context(source, node, 3);
-                    
-                    results.push(SearchResult {
-                        file_path: file_path.to_path_buf(),
-                        line_number: start.row + 1,
-                        column: start.column,
-                        match_text,
-                        context_before,
-                        context_after,
-                        match_type: MatchType::Ast,
-                        score: 0.95,
-                        node_type: Some(node.kind().to_string()),
-                        semantic_context: Some(get_semantic_context(node, source)),
-                    });
-                }
+/// Search within a parsed tree.
+fn search_tree(
+    tree: &tree_sitter::Tree,
+    grammar: &Language,
+    source: &str,
+    pattern: &str,
+    file_path: &Path,
+    language: &str,
+) -> Vec<SearchResult> {
+    let mut results = Vec::new();
+    let root_node = tree.root_node();
+
+    // Build query based on pattern.
+    let query_str = build_query_string(pattern, language);
+
+    if let Ok(query) = Query::new(grammar, &query_str) {
+        let mut cursor = QueryCursor::new();
+        let mut matches = cursor.matches(&query, root_node, source.as_bytes());
+
+        // `QueryMatches` is a streaming iterator in tree-sitter >= 0.22.
+        while let Some(match_) = matches.next() {
+            for capture in match_.captures {
+                let node = capture.node;
+                let start = node.start_position();
+
+                let match_text = source[node.byte_range()].to_string();
+                let (context_before, context_after) = get_context(source, node, 3);
+
+                results.push(SearchResult {
+                    file_path: file_path.to_path_buf(),
+                    line_number: start.row + 1,
+                    column: start.column,
+                    match_text,
+                    context_before,
+                    context_after,
+                    match_type: MatchType::Ast,
+                    score: 0.95,
+                    node_type: Some(node.kind().to_string()),
+                    semantic_context: Some(get_semantic_context(node, source)),
+                });
             }
-        } else {
-            // Fallback to pattern matching on node text
-            results.extend(search_nodes_by_text(
-                root_node,
-                source,
-                pattern,
-                file_path,
-            ));
         }
-        
-        results
+    } else {
+        // Fallback to pattern matching on node text.
+        results.extend(search_nodes_by_text(root_node, source, pattern, file_path));
     }
+
+    results
 }
 
 /// Detect language from file extension
@@ -183,21 +180,39 @@ fn build_query_string(pattern: &str, language: &str) -> String {
     if pattern.starts_with("function ") {
         let name = pattern.trim_start_matches("function ").trim();
         match language {
-            "rust" => format!("(function_item name: (identifier) @fn (#eq? @fn \"{}\"))", name),
+            "rust" => format!(
+                "(function_item name: (identifier) @fn (#eq? @fn \"{}\"))",
+                name
+            ),
             "javascript" | "typescript" => {
-                format!("(function_declaration name: (identifier) @fn (#eq? @fn \"{}\"))", name)
+                format!(
+                    "(function_declaration name: (identifier) @fn (#eq? @fn \"{}\"))",
+                    name
+                )
             }
-            "python" => format!("(function_definition name: (identifier) @fn (#eq? @fn \"{}\"))", name),
+            "python" => format!(
+                "(function_definition name: (identifier) @fn (#eq? @fn \"{}\"))",
+                name
+            ),
             _ => format!("(identifier) @id (#eq? @id \"{}\")", name),
         }
     } else if pattern.starts_with("class ") {
         let name = pattern.trim_start_matches("class ").trim();
         match language {
-            "rust" => format!("(struct_item name: (type_identifier) @struct (#eq? @struct \"{}\"))", name),
+            "rust" => format!(
+                "(struct_item name: (type_identifier) @struct (#eq? @struct \"{}\"))",
+                name
+            ),
             "javascript" | "typescript" => {
-                format!("(class_declaration name: (identifier) @class (#eq? @class \"{}\"))", name)
+                format!(
+                    "(class_declaration name: (identifier) @class (#eq? @class \"{}\"))",
+                    name
+                )
             }
-            "python" => format!("(class_definition name: (identifier) @class (#eq? @class \"{}\"))", name),
+            "python" => format!(
+                "(class_definition name: (identifier) @class (#eq? @class \"{}\"))",
+                name
+            ),
             _ => format!("(identifier) @id (#eq? @id \"{}\")", name),
         }
     } else {
@@ -215,16 +230,16 @@ fn search_nodes_by_text(
 ) -> Vec<SearchResult> {
     let mut results = Vec::new();
     let mut cursor = node.walk();
-    
+
     // Visit all nodes
     loop {
         let node = cursor.node();
         let node_text = source[node.byte_range()].to_string();
-        
+
         // Check if node text contains pattern
         if node_text.contains(pattern) {
             let start = node.start_position();
-            
+
             results.push(SearchResult {
                 file_path: file_path.to_path_buf(),
                 line_number: start.row + 1,
@@ -238,7 +253,7 @@ fn search_nodes_by_text(
                 semantic_context: Some(get_semantic_context(node, source)),
             });
         }
-        
+
         // Traverse tree
         if cursor.goto_first_child() {
             continue;
@@ -246,7 +261,7 @@ fn search_nodes_by_text(
         if cursor.goto_next_sibling() {
             continue;
         }
-        
+
         loop {
             if !cursor.goto_parent() {
                 return results;
@@ -263,37 +278,38 @@ fn get_context(source: &str, node: Node, context_lines: usize) -> (Vec<String>, 
     let lines: Vec<&str> = source.lines().collect();
     let start_line = node.start_position().row;
     let end_line = node.end_position().row;
-    
+
     let before_start = start_line.saturating_sub(context_lines);
     let after_end = std::cmp::min(end_line + context_lines + 1, lines.len());
-    
+
     let context_before = lines[before_start..start_line]
         .iter()
         .map(|s| s.to_string())
         .collect();
-    
+
     let context_after = lines[(end_line + 1)..after_end]
         .iter()
         .map(|s| s.to_string())
         .collect();
-    
+
     (context_before, context_after)
 }
 
 /// Get semantic context for a node
 fn get_semantic_context(node: Node, source: &str) -> String {
-    let mut context = format!("{} at {}:{}", 
+    let mut context = format!(
+        "{} at {}:{}",
         node.kind(),
         node.start_position().row + 1,
         node.start_position().column
     );
-    
+
     // Find parent function or class
     if let Some(parent) = find_parent_context(node) {
         let parent_text = source[parent.byte_range()].lines().next().unwrap_or("");
         context.push_str(&format!(" in {}", parent_text));
     }
-    
+
     context
 }
 
@@ -301,9 +317,14 @@ fn get_semantic_context(node: Node, source: &str) -> String {
 fn find_parent_context(mut node: Node) -> Option<Node> {
     while let Some(parent) = node.parent() {
         match parent.kind() {
-            "function_item" | "function_declaration" | "function_definition" |
-            "method_definition" | "struct_item" | "class_declaration" | 
-            "class_definition" | "impl_item" => {
+            "function_item"
+            | "function_declaration"
+            | "function_definition"
+            | "method_definition"
+            | "struct_item"
+            | "class_declaration"
+            | "class_definition"
+            | "impl_item" => {
                 return Some(parent);
             }
             _ => node = parent,
@@ -316,16 +337,68 @@ fn find_parent_context(mut node: Node) -> Option<Node> {
 mod tests {
     use super::*;
 
+    #[test]
+    fn test_searcher_loads_all_grammars() {
+        // Construction fails loudly if any grammar's parser ABI is
+        // incompatible with the linked tree-sitter core.
+        let searcher = AstSearcher::new().expect("all grammars must load (ABI must match core)");
+        assert_eq!(searcher.languages.len(), GRAMMARS.len());
+    }
+
+    /// Parse a tiny snippet for `lang` and assert the tree is sane:
+    /// a non-empty root whose kind matches `expected_root`, with no error nodes.
+    fn assert_parses_clean(searcher: &AstSearcher, lang: &str, source: &str, expected_root: &str) {
+        let (tree, _grammar) = searcher
+            .parse(lang, source)
+            .unwrap_or_else(|| panic!("{lang}: parser produced no tree"));
+        let root = tree.root_node();
+        assert_eq!(root.kind(), expected_root, "{lang}: unexpected root kind");
+        assert!(root.child_count() > 0, "{lang}: root has no children");
+        assert!(
+            !root.has_error(),
+            "{lang}: tree contains error nodes (ABI/grammar mismatch?)"
+        );
+        assert_eq!(
+            root.start_byte(),
+            0,
+            "{lang}: root does not start at byte 0"
+        );
+        assert_eq!(
+            root.end_byte(),
+            source.len(),
+            "{lang}: root does not cover whole source"
+        );
+    }
+
+    #[test]
+    fn test_parse_c_snippet() {
+        let searcher = AstSearcher::new().expect("grammars must load");
+        assert_parses_clean(
+            &searcher,
+            "c",
+            "int add(int a, int b) { return a + b; }\n",
+            "translation_unit",
+        );
+    }
+
+    #[test]
+    fn test_parse_rust_snippet() {
+        let searcher = AstSearcher::new().expect("grammars must load");
+        assert_parses_clean(
+            &searcher,
+            "rust",
+            "fn add(a: i32, b: i32) -> i32 { a + b }\n",
+            "source_file",
+        );
+    }
+
     #[tokio::test]
     async fn test_ast_search() {
-        let searcher = AstSearcher::new();
-        let results = searcher.search(
-            "function test",
-            Path::new("."),
-            Some("rust"),
-            10,
-        ).await;
-        
+        let searcher = AstSearcher::new().expect("grammars must load");
+        let results = searcher
+            .search("function test", Path::new("."), Some("rust"), 10)
+            .await;
+
         assert!(results.is_ok());
     }
 

--- a/crates/hanzo-mcp-server/src/search/mod.rs
+++ b/crates/hanzo-mcp-server/src/search/mod.rs
@@ -1,11 +1,15 @@
-/// Unified search module for Rust MCP
-/// Provides text, AST, symbol, vector, and memory search capabilities
+//! Search module for Rust MCP.
+//!
+//! `ast_search` is the live, tested path (tree-sitter semantic search).
+//! The text/symbol/vector/unified searchers predate the active build graph and
+//! do not yet compile against current deps; they stay disabled until refactored
+//! — same convention as the disabled workspace crates in LLM.md.
 
-pub mod unified_search;
 pub mod ast_search;
-pub mod symbol_search;
-pub mod vector_store;
-pub mod search;
+// pub mod unified_search;
+// pub mod symbol_search;
+// pub mod vector_store;
+// pub mod search;
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -35,119 +39,4 @@ pub enum MatchType {
     Vector,
     Memory,
     File,
-}
-
-/// Search modality enum
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SearchModality {
-    Text,
-    Ast,
-    Symbol,
-    Vector,
-    Memory,
-    File,
-}
-
-/// Search configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SearchConfig {
-    pub query: String,
-    pub path: Option<PathBuf>,
-    pub modalities: Vec<SearchModality>,
-    pub max_results: usize,
-    pub context_lines: usize,
-    pub file_pattern: Option<String>,
-    pub language: Option<String>,
-}
-
-impl Default for SearchConfig {
-    fn default() -> Self {
-        Self {
-            query: String::new(),
-            path: Some(PathBuf::from(".")),
-            modalities: vec![],
-            max_results: 20,
-            context_lines: 3,
-            file_pattern: None,
-            language: None,
-        }
-    }
-}
-
-/// Detect search modalities based on query
-pub fn detect_modalities(query: &str) -> Vec<SearchModality> {
-    let mut modalities = Vec::new();
-    
-    // Natural language query - use vector search
-    if query.split_whitespace().count() > 3 && !has_code_pattern(query) {
-        modalities.push(SearchModality::Vector);
-    }
-    
-    // Code patterns - use AST search
-    if has_code_pattern(query) {
-        modalities.push(SearchModality::Ast);
-    }
-    
-    // Single identifier - use symbol search
-    if is_identifier(query) {
-        modalities.push(SearchModality::Symbol);
-    }
-    
-    // Always include text search as fallback
-    modalities.push(SearchModality::Text);
-    
-    // File pattern
-    if query.contains('/') || query.contains('.') {
-        modalities.push(SearchModality::File);
-    }
-    
-    modalities.dedup();
-    modalities
-}
-
-/// Check if query contains code patterns
-fn has_code_pattern(query: &str) -> bool {
-    let patterns = [
-        "class ", "function ", "def ", "interface ", "struct ",
-        "enum ", "type ", "const ", "let ", "var ", "import ",
-        "from ", "fn ", "impl ", "trait ", "pub ",
-    ];
-    
-    patterns.iter().any(|pattern| query.contains(pattern))
-}
-
-/// Check if query is a single identifier
-fn is_identifier(query: &str) -> bool {
-    query.chars().all(|c| c.is_alphanumeric() || c == '_') &&
-    query.chars().next().map_or(false, |c| c.is_alphabetic() || c == '_')
-}
-
-/// Rank and deduplicate search results
-pub fn rank_and_deduplicate(mut results: Vec<SearchResult>, max_results: usize) -> Vec<SearchResult> {
-    // Remove duplicates by file path and line number
-    results.sort_by(|a, b| {
-        a.file_path.cmp(&b.file_path)
-            .then_with(|| a.line_number.cmp(&b.line_number))
-    });
-    results.dedup_by(|a, b| {
-        a.file_path == b.file_path && a.line_number == b.line_number
-    });
-    
-    // Sort by score and match type priority
-    let priority = |m: &MatchType| match m {
-        MatchType::Symbol => 1,
-        MatchType::Ast => 2,
-        MatchType::Vector => 3,
-        MatchType::Text => 4,
-        MatchType::Memory => 5,
-        MatchType::File => 6,
-    };
-    
-    results.sort_by(|a, b| {
-        b.score.partial_cmp(&a.score).unwrap()
-            .then_with(|| priority(&a.match_type).cmp(&priority(&b.match_type)))
-    });
-    
-    results.truncate(max_results);
-    results
 }


### PR DESCRIPTION
## Problem

PRs #69 (tree-sitter-c 0.20→0.24) and #65 (tree-sitter-rust 0.20→0.24) bumped two grammars to **parser ABI 15** while the core `tree-sitter` crate stayed at **0.20** (max ABI 14). Two things made this a *silent* break:

1. `ast_search.rs` loaded grammars through a hand-rolled `extern "C" fn tree_sitter_*() -> Language` block (undefined behavior once `Language` stopped being a bare pointer in 0.22+) and discarded the result with `parser.set_language(language).ok()`. An ABI-mismatched grammar fails inside `set_language` at **runtime**, and `.ok()` swallowed it.
2. The `search` module was **never declared in `lib.rs`** — so `ast_search.rs` and every `tree-sitter` dependency were dead code that never compiled. `cargo build`/`cargo test` "passed" because nothing actually parsed.

Confirmed empirically: a 0.20 core can't even accept a 0.24 grammar's `LanguageFn` (`Language: From<LanguageFn>` is unimplemented in 0.20), which is exactly why the original code bypassed the safe API with raw FFI and shipped a latent runtime failure.

## Fix — forward to latest, ABI-consistent across the whole set

- **Core `tree-sitter` 0.20 → 0.26** (ABI 15 capable); **all 8 grammars aligned to latest** (rust/c `0.24`, js/python/go `0.25`, ts/java/cpp `0.23`). Leaving the other 6 grammars at 0.20 against a 0.26 core would be the same class of latent break.
- **Removed the unsafe `extern "C"` FFI block.** Each grammar is now loaded from its crate's `LANGUAGE: LanguageFn` constant (via `tree-sitter-language`, the canonical home of the type). Migrated to the 0.26 API: `set_language(&Language)`, `Query::new(&Language, …)`, and `StreamingIterator` for `QueryMatches`.
- **`AstSearcher::new()` now returns `Result`** and validates every grammar's ABI up front, **propagating `LanguageError`** instead of `.ok()`. An ABI mismatch is now loud.
- **Wired `pub mod search;` into `lib.rs`** so the code is actually compiled and the tests run. The sibling searchers (`search.rs`/`vector_store.rs`/`unified_search.rs`/`symbol_search.rs`) predate the active build graph and don't compile against current deps (renamed types, an absent `lance` crate, stale trait bounds) — they stay disabled with a documented reason (same convention as the disabled crates in `LLM.md`). `mod.rs` trimmed to just the `SearchResult`/`MatchType` types `ast_search` uses.
- **Added parse tests** that exercise the real grammars:
  - `test_parse_c_snippet` — parses `int add(...)`, asserts root `translation_unit`, no error nodes, full byte coverage.
  - `test_parse_rust_snippet` — parses `fn add(...)`, asserts root `source_file`, no error nodes.
  - `test_searcher_loads_all_grammars` — every grammar's ABI loads against the core.

This can no longer silently regress: an ABI mismatch fails to compile (safe API) or fails `new()`/the parse tests (loud).

## Verification (`hanzo-mcp-server`)

- `cargo build` — clean
- `cargo test` — **14 passed, 0 failed** (incl. the 3 new tests)
- `cargo fmt --check` — clean
- `cargo clippy --all-targets` — clean
- Full workspace `cargo build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)